### PR TITLE
fix(shebang): avoid node arguments

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,17 +1,16 @@
-  env:
-    node: true
-    es2022: true
-  extends: 
-    - "eslint:recommended"
-    - "plugin:import/recommended" 
-    - "prettier"
-  plugins: 
-    - import
-  parserOptions:
-    ecmaVersion: "latest"
-    sourceType: "module"
-  ignorePatterns: ["src/utils/version.js"]
-  rules:
-    "import/order":
-      - error
-      - newlines-between: always
+env:
+  node: true
+  es2022: true
+extends:
+  - "eslint:recommended"
+  - "plugin:import/recommended"
+  - "prettier"
+plugins:
+  - import
+parserOptions:
+  ecmaVersion: "latest"
+  sourceType: "module"
+rules:
+  "import/order":
+    - error
+    - newlines-between: always

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v3
@@ -24,3 +23,20 @@ jobs:
           cache: "yarn"
       - run: yarn --frozen-lockfile
       - run: yarn lint
+  healthcheck:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+      - run: yarn --frozen-lockfile
+      - run: npm install -g .
+      - run: genai --version

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import { parser } from "./parser.js";
 import { isUsageError } from "./errors.js";

--- a/src/middleware/client.js
+++ b/src/middleware/client.js
@@ -1,6 +1,5 @@
 import { Client } from "@ibm-generative-ai/node-sdk";
 
-// eslint-disable-next-line import/namespace
 import { version } from "../utils/version.js";
 
 export const clientMiddleware = (args) => {

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -1,3 +1,5 @@
-import pkg from "../../package.json" assert { type: "json" };
+import { readFile } from 'node:fs/promises';
+
+const pkg = JSON.parse(await readFile(new URL('../../package.json', import.meta.url)));
 
 export const version = pkg.version;


### PR DESCRIPTION
Supplying arguments in shebang unfortunately doesn't work on Linux (--no-warnings in our case).

Since there is no good solution for that, we're replacing experimental feature that caused the warnings with its runtime alternative. This achieves the desired outcome. Simple healthcheck job has been added as well.